### PR TITLE
Configure npm install for workspace compatibility

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/apps/thorbis-components/package.json
+++ b/apps/thorbis-components/package.json
@@ -10,7 +10,7 @@
 		"clean": "rimraf .next"
 	},
 	"dependencies": {
-		"@thorbis/web": "workspace:*",
+                "@thorbis/web": "*",
 		"next": "14.2.16",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",

--- a/apps/thorbis-example-website/package.json
+++ b/apps/thorbis-example-website/package.json
@@ -9,7 +9,7 @@
 		"lint": "next lint"
 	},
 	"dependencies": {
-		"@thorbis/web": "workspace:*",
+                "@thorbis/web": "*",
 		"next": "14.2.16",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",

--- a/apps/thorbis-powerpoint/package.json
+++ b/apps/thorbis-powerpoint/package.json
@@ -37,7 +37,7 @@
 		"@radix-ui/react-toggle": "^1.1.0",
 		"@radix-ui/react-toggle-group": "^1.1.0",
 		"@radix-ui/react-tooltip": "^1.1.4",
-		"@thorbis/web": "workspace:*",
+                "@thorbis/web": "*",
 		"class-variance-authority": "^0.7.0",
 		"clsx": "^2.1.1",
 		"cmdk": "1.0.0",

--- a/apps/thorbis/package.json
+++ b/apps/thorbis/package.json
@@ -20,9 +20,8 @@
 		"next": "14.2.16",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
-		"tailwind-merge": "^2.2.1",
-		"thorbis": "link:thorbis"
-	},
+                "tailwind-merge": "^2.2.1"
+        },
 	"devDependencies": {
 		"@types/node": "^20.0.0",
 		"@types/react": "^18.2.0",

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "version": 2,
+  "installCommand": "npm install",
+  "buildCommand": "npm run build"
+}


### PR DESCRIPTION
## Summary
- add npm config to accept legacy peer dependencies
- create root Vercel config using npm install and build commands
- replace bun-specific workspace links with npm-friendly versions

## Testing
- `npm install`
- `npm test` *(fails: Missing script "test" ")*
- `npm run lint` *(fails: command exited (1))*

------
https://chatgpt.com/codex/tasks/task_e_68a4505b541c8326aa8079b30c4a33e8