### PR TITLE
fix: ignore peer dependency errors on vercel

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,5 @@
 {
   "version": 2,
-  "installCommand": "npm install",
+  "installCommand": "npm install --legacy-peer-deps",
   "buildCommand": "npm run build"
 }


### PR DESCRIPTION
## Summary
- ensure Vercel install uses `--legacy-peer-deps`

## Testing
- `bun run lint` (fails: no-unused-vars in `apps/thorbis-powerpoint`)


------
https://chatgpt.com/codex/tasks/task_e_68a45477d03083268ab96a9da3aa3203