### PR TITLE
fix: ignore peer dependency errors on vercel

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,7 @@
 {
   "version": 2,
-  "installCommand": "npm install",
-  "buildCommand": "npm run build"
+  "buildCommand": "npm run build",
+  "env": {
+    "NPM_FLAGS": "--legacy-peer-deps"
+  }
 }


### PR DESCRIPTION
## Summary
- configure Vercel to pass `--legacy-peer-deps` to npm via `NPM_FLAGS`

## Testing
- `bun run lint` *(fails: 'props' and other variables are defined but never used in `apps/thorbis-powerpoint`)*

------
https://chatgpt.com/codex/tasks/task_e_68a45477d03083268ab96a9da3aa3203